### PR TITLE
Add semver 7.7.2 as optional dependency in sharp module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8193,6 +8193,19 @@
         "@img/sharp-win32-x64": "0.33.5"
       }
     },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",


### PR DESCRIPTION
This change adds semver version 7.7.2 as an optional dependency within the sharp module's node_modules.

The semver package is added with:
- Version 7.7.2
- ISC license
- Optional dependency flag
- Binary executable at bin/semver.js
- Node.js engine requirement >=10

This appears to be an automatic dependency resolution update in the package-lock.json file.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5c56a800766449d5a041038631342b0a/spark-realm)

👀 [Preview Link](https://5c56a800766449d5a041038631342b0a-spark-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5c56a800766449d5a041038631342b0a</projectId>-->
<!--<branchName>spark-realm</branchName>-->